### PR TITLE
Fixes crash on iOS 9.3.5 or Earlier

### DIFF
--- a/CTNotificationService.podspec
+++ b/CTNotificationService.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = { "CleverTap" => "http://www.clevertap.com" }
   s.source           = { :git => "https://github.com/CleverTap/CTNotificationService.git", :tag => s.version.to_s }
   s.requires_arc = true
-  s.platform = :ios, '10.0'
+  s.ios.deployment_target  = '10.0'
   s.source_files = 'CTNotificationService/*.{m,h}' 
   s.weak_frameworks = 'UserNotifications'
 end

--- a/CTNotificationService.podspec
+++ b/CTNotificationService.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.platform = :ios, '10.0'
   s.source_files = 'CTNotificationService/*.{m,h}' 
+  s.weak_frameworks = 'UserNotifications'
 end

--- a/CTNotificationService.podspec
+++ b/CTNotificationService.podspec
@@ -7,7 +7,8 @@ Pod::Spec.new do |s|
   s.author           = { "CleverTap" => "http://www.clevertap.com" }
   s.source           = { :git => "https://github.com/CleverTap/CTNotificationService.git", :tag => s.version.to_s }
   s.requires_arc = true
-  s.ios.deployment_target  = '10.0'
   s.source_files = 'CTNotificationService/*.{m,h}' 
+
+  s.ios.deployment_target  = '10.0'
   s.weak_frameworks = 'UserNotifications'
 end


### PR DESCRIPTION
Added deployment target and weak framework in the podspec to have optional binding of the framework to the target so that it doesn't crash the app which are installed on iOS 9.3.5 or earlier