### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change Log
 ==========
+Version 0.1.7 (17 April, 2024)
+-----------------------------------------------
+- Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.
+- Fixes the error "Missing an expected key: 'NSPrivacyCollectedDataTypes'" when generating a privacy report.
+
 Version 0.1.6 (20 March, 2024)
 -----------------------------------------------
 - Adds privacy manifests.

--- a/CTNotificationService.podspec
+++ b/CTNotificationService.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '10.0'
   s.weak_frameworks  = 'UserNotifications'
   s.source_files     = 'CTNotificationService/*.{m,h}' 
-  s.resources = 'CTNotificationService/*.{xcprivacy}'
+  s.resource_bundles = { 'CTNotificationService' => 'CTNotificationService/*.{xcprivacy}' }
 end

--- a/CTNotificationService.podspec
+++ b/CTNotificationService.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CTNotificationService"
-  s.version          = "0.1.6"
+  s.version          = "0.1.7"
   s.summary          = "A simple Notification Service Extension class to add media attachments to iOS 10 rich push notifications."
   s.homepage         = "https://github.com/CleverTap/CTNotificationService"
   s.license          = "MIT" 

--- a/CTNotificationService/PrivacyInfo.xcprivacy
+++ b/CTNotificationService/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
- Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.
- Fixes the error "Missing an expected key: 'NSPrivacyCollectedDataTypes'" when generating a privacy report.